### PR TITLE
Modify logic for redirect new user to group page.

### DIFF
--- a/javascripts/discourse/initializers/techcommunity-redirect-new-users.js.es6
+++ b/javascripts/discourse/initializers/techcommunity-redirect-new-users.js.es6
@@ -4,28 +4,61 @@ import DiscourseURL from "discourse/lib/url";
 export default {
   name: "techcommunity-redirect-new-users",
   initialize() {
-    withPluginApi("0.8", (api) => {
-        //Get the current User and return (break the execution) if User is not first time visitor.
-        const current_user = api.getCurrentUser();
+    withPluginApi("0.8", (api) => {      
+        api.onPageChange((url) => {
+            const firstNotificationTippy = document.querySelector(".d-header .d-header-icons + div[data-tippy-root]");
+            if(firstNotificationTippy) {
+              if(/^\/g$/.test(url) || /^\/groups$/.test(url)){
+                firstNotificationTippy.style.transform = "translate(-6px, 47px)";
+              } else {
+                firstNotificationTippy.style.transform = "translate(-119px, 47px)";
+              }   
+            } 
+        });
         //Below code will execute after rendering "header-notifications" widget. And if the User is first time visitor he will be redirected to the Goups page.
-        api.decorateWidget("header-notifications:after", helper => {
-            if (!current_user || current_user.read_first_notification || current_user.enforcedSecondFactor) {
-                return "";
+         api.decorateWidget("header-notifications:after", helper => {
+            const path = window.location.pathname;
+            const attrs = helper.attrs;
+            const { user } = attrs;
+            
+            if (!user ) {
+              return "";
             }
+            if(/^\/g$/.test(path) || /^\/groups$/.test(path)) {
+              return "";
+            }
+           
+            const seenUserTips = user.seen_popups || [];
+            if (seenUserTips.includes(-1) || seenUserTips.includes(1)) {
+              return;
+            }
+           
+            let shouldRedirectToGroupPage = false;
+            if (user && !user.read_first_notification && !user.enforcedSecondFactor && !attrs.active) {
+              shouldRedirectToGroupPage = true;
+            } else {
+              return "";
+            }
+             
+            if(localStorage.getItem("redirectToGroupPage" + user.id)) {
+              return;
+            }
+            
             //Fetching Group names from current_user object [Added By: Saurabh, Date: 12/05/2021]
             var currentuserGroups = [];
-            (current_user.groups).forEach(function (groupObj, index) {
+            (user.groups).forEach(function (groupObj, index) {
                 currentuserGroups.push(String(groupObj.name).toLowerCase());
             });
             //If User not belongs to alfabet-users group and are first-time visitor then redirect User to Groups page [Modified By: Saurabh, Date: 12/05/2021]
             if(currentuserGroups.indexOf(("alfabet-users").toLowerCase()) == -1){
-                //If the User login First-time visitor then he will be redirect to Groups page.
-                if (!helper.attrs.active && helper.attrs.ringBackdrop) {   
-                    DiscourseURL.routeTo("/g");
-                    return "";
-                }
+              //If the User login First-time visitor then he will be redirect to Groups page.
+              if(shouldRedirectToGroupPage) {
+                localStorage.setItem("redirectToGroupPage" + user.id, "true");
+                DiscourseURL.routeTo("/g");
+                return "";
+              }
             }
-        });      
+        });
     });
   },
 };


### PR DESCRIPTION
Discourse has removed the old First notification tutorial and added a user-tips new feature. So we change the logic to redirect the new user to the group page based on the user-tips feature.